### PR TITLE
Lite server should only watch relevant files

### DIFF
--- a/generators/app/templates/bs-config.json
+++ b/generators/app/templates/bs-config.json
@@ -1,4 +1,8 @@
 {
+  "files": [
+    "./dist/**/*",
+    "/.playground/**/*"
+  ],
   "server": {
     "baseDir": "src",
     "routes": {


### PR DESCRIPTION
As mentioned in #228 (comment) sometimes the light server tries to access files in .tmp or tmp and we crash on cleanup in those cases.

As it has no business accessing those file anyway, we now listen to the build and playground dir directly.

Stolen from https://github.com/jvandemo/generator-angular2-library/pull/290